### PR TITLE
Add 'exit game' button (mapped to SELECT by default)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@
 *.app
 *.hex
 
+# OpenDingux package files
+*.opk
+
 # Debug files
 *.dSYM/
 *.su

--- a/src/pc/configfile.c
+++ b/src/pc/configfile.c
@@ -61,6 +61,7 @@ unsigned int configKeyStickUp    = 0x0200;
 unsigned int configKeyStickDown  = 0x0200;
 unsigned int configKeyStickLeft  = 0x0200;
 unsigned int configKeyStickRight = 0x0200;
+unsigned int configKeyExit       = 0x0101; /* SELECT button */
 #endif
 
 
@@ -79,6 +80,9 @@ static const struct ConfigOption options[] = {
     {.name = "key_stickdown",  .type = CONFIG_TYPE_UINT, .uintValue = &configKeyStickDown},
     {.name = "key_stickleft",  .type = CONFIG_TYPE_UINT, .uintValue = &configKeyStickLeft},
     {.name = "key_stickright", .type = CONFIG_TYPE_UINT, .uintValue = &configKeyStickRight},
+#ifdef TARGET_OD
+    {.name = "key_exit",       .type = CONFIG_TYPE_UINT, .uintValue = &configKeyExit},
+#endif
 };
 
 // Reads an entire line from a file (excluding the newline character) and returns an allocated string

--- a/src/pc/configfile.h
+++ b/src/pc/configfile.h
@@ -15,6 +15,9 @@ extern unsigned int configKeyStickUp;
 extern unsigned int configKeyStickDown;
 extern unsigned int configKeyStickLeft;
 extern unsigned int configKeyStickRight;
+#ifdef TARGET_OD
+extern unsigned int configKeyExit;
+#endif
 
 void configfile_load(const char *filename);
 void configfile_save(const char *filename);

--- a/src/pc/controller/controller_keyboard.c
+++ b/src/pc/controller/controller_keyboard.c
@@ -9,6 +9,10 @@
 
 #include "../configfile.h"
 
+#ifdef TARGET_OD
+#include "../dingux.h"
+#endif
+
 static int keyboard_buttons_down;
 
 static int keyboard_mapping[13][2];
@@ -26,6 +30,11 @@ static int keyboard_map_scancode(int scancode) {
 bool keyboard_on_key_down(int scancode) {
     int mapped = keyboard_map_scancode(scancode);
     keyboard_buttons_down |= mapped;
+#ifdef TARGET_OD
+    if (scancode == (int)configKeyExit) {
+       gExitGame = 1;
+    }
+#endif
     return mapped != 0;
 }
 

--- a/src/pc/dingux.h
+++ b/src/pc/dingux.h
@@ -1,0 +1,10 @@
+#ifdef TARGET_OD
+
+#ifndef DINGUX_H
+#define DINGUX_H
+
+extern unsigned int gExitGame;
+
+#endif /* DINGUX_H */
+
+#endif /* TARGET_OD */

--- a/src/pc/gfx/gfx_sdl2.c
+++ b/src/pc/gfx/gfx_sdl2.c
@@ -24,6 +24,10 @@
 #include "gfx_window_manager_api.h"
 #include "gfx_screen_config.h"
 
+#ifdef TARGET_OD
+#include "../dingux.h"
+#endif
+
 #define GFX_API_NAME "SDL2 - OpenGL"
 
 static SDL_Window *wnd;
@@ -218,7 +222,11 @@ static void gfx_sdl_set_keyboard_callbacks(bool (*on_key_down)(int scancode), bo
 }
 
 static void gfx_sdl_main_loop(void (*run_one_game_iter)(void)) {
+#ifdef TARGET_OD
+    while (!gExitGame) {
+#else
     while (1) {
+#endif
         run_one_game_iter();
     }
 }

--- a/src/pc/pc_main.c
+++ b/src/pc/pc_main.c
@@ -33,6 +33,11 @@
 #include "compat.h"
 #include "cheapProfiler.h"
 
+#ifdef TARGET_OD
+#include "dingux.h"
+unsigned int gExitGame = 0;
+#endif
+
 #define CONFIG_FILE "sm64config.txt"
 
 OSMesg D_80339BEC;
@@ -279,7 +284,11 @@ void main_func(void) {
     inited = 1;
 #else
     inited = 1;
+#ifdef TARGET_OD
+    while (!gExitGame) {
+#else
     while (1) {
+#endif
         wm_api->main_loop(produce_one_frame);
     }
 #endif


### PR DESCRIPTION
At present, the OpenDingux port can only be exited by killing the process via POWER+SELECT. This PR adds a dedicated quit button, mapped to SELECT by default. This is particularly useful on RG350M devices, which have notoriously fragile power buttons.

The changes here are mostly lifted from https://github.com/AdrienLombard/sm64-351elec-port/commit/03e181b19395857e650b3b6e1f477f9ada8bcf95